### PR TITLE
docs: remove dependency viz + [all] extras from README & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ Requires **Python 3.11+**.
 pip install fastexec
 ```
 
-For visualization support (dependency graph rendering):
-
-```bash
-pip install fastexec[all]
-```
-
 ## Quick Start
 
 ```python
@@ -200,22 +194,6 @@ app = FastExec()
 app.include_pipeline(parent, prefix="/parent")
 
 await app.exec("/parent/child/detail")  # -> {"detail": "nested"}
-```
-
-## Dependency Visualization
-
-Understand your dependency tree with built-in visualization:
-
-```bash
-pip install fastexec[all]
-```
-
-```python
-from fastexec import get_dependant
-from fastexec.utils.graph import visualize_dependant, save_dependant_graph_image
-
-dependant = get_dependant(call=my_endpoint)
-save_dependant_graph_image(dependant, "deps.png", name="My Dependencies")
 ```
 
 ## Examples

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -15,11 +15,3 @@
 ## fastexec.get_dependant
 
 ::: fastexec.get_dependant
-
----
-
-## fastexec.utils.graph
-
-::: fastexec.utils.graph.visualize_dependant
-
-::: fastexec.utils.graph.save_dependant_graph_image

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,12 +11,6 @@
 pip install fastexec
 ```
 
-For dependency graph visualization support:
-
-```bash
-pip install fastexec[all]
-```
-
 ## Your First Pipeline
 
 ```python


### PR DESCRIPTION
## 🧹 Docs: drop visualization / `fastexec[all]` from main guides

### What changed
- 📦 Removed install hints for `fastexec[all]` from **README** and **getting started**
- 📊 Removed the whole **Dependency Visualization** section (sample code + `pip install fastexec[all]`) from **README**
- 📖 Trimmed **API reference**: no more `fastexec.utils.graph` entries (`visualize_dependant`, `save_dependant_graph_image`)

### Why
- ✨ Keeps default docs focused on the core install path (`pip install fastexec`) and everyday usage
- 🎯 Avoids promising extras in the primary docs if visualization is optional, moved, or deprecated

### Files touched
- `README.md`
- `docs/getting-started.md`
- `docs/api-reference.md`
